### PR TITLE
Correct the FSF's address in three files.

### DIFF
--- a/postgres/gnatcoll-sql-postgres-gnade.adb
+++ b/postgres/gnatcoll-sql-postgres-gnade.adb
@@ -19,8 +19,8 @@
 --  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
 --  for  more details.  You should have  received  a copy of the GNU General --
 --  Public License  distributed with GNAT;  see file COPYING.  If not, write --
---  to  the Free Software Foundation,  59 Temple Place - Suite 330,  Boston, --
---  MA 02111-1307, USA.                                                      --
+--  to  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, --
+--  Boston, MA 02110-1301, USA.                                              --
 --                                                                           --
 --  As a special exception,  if other files  instantiate  generics from this --
 --  unit, or you link  this unit with other files  to produce an executable, --

--- a/postgres/gnatcoll-sql-postgres-gnade.ads
+++ b/postgres/gnatcoll-sql-postgres-gnade.ads
@@ -13,8 +13,8 @@
 --  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
 --  for  more details.  You should have  received  a copy of the GNU General --
 --  Public License  distributed with GNAT;  see file COPYING.  If not, write --
---  to  the Free Software Foundation,  59 Temple Place - Suite 330,  Boston, --
---  MA 02111-1307, USA.                                                      --
+--  to  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, --
+--  Boston, MA 02110-1301, USA.                                              --
 --                                                                           --
 --  As a special exception,  if other files  instantiate  generics from this --
 --  unit, or you link  this unit with other files  to produce an executable, --

--- a/sqlite/gnatcoll-sql-sqlite.adb
+++ b/sqlite/gnatcoll-sql-sqlite.adb
@@ -21,8 +21,8 @@
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU --
 -- General Public License for more details. You should have received --
 -- a copy of the GNU General Public License along with this program; --
--- if not,  write to the  Free Software Foundation, Inc.,  59 Temple --
--- Place - Suite 330, Boston, MA 02111-1307, USA.                    --
+-- if not,  write to the Free Software Foundation, Inc., 51 Franklin --
+-- Street, Fifth Floor, Boston, MA 02110-1301, USA.                  --
 -----------------------------------------------------------------------
 
 with GNATCOLL.SQL.Sqlite.Builder;


### PR DESCRIPTION
In a package review in Fedora we discovered that three files contain an outdated address to the Free Software Foundation.