### PR TITLE
sqlite/gnatcoll_sqlite.gpr: fix static build if Library_Type is external

### DIFF
--- a/sqlite/gnatcoll_sqlite.gpr
+++ b/sqlite/gnatcoll_sqlite.gpr
@@ -69,7 +69,12 @@ project GnatColl_Sqlite is
          for Source_Dirs use (".", "amalgamation");
       when "external" =>
          for Source_Dirs use (".");
-         for Library_Options use ("-lsqlite3") & Thread_Lib;
+         case Library_Type is
+            when "relocatable" =>
+               for Library_Options use ("-lsqlite3") & Thread_Lib;
+            when others =>
+               null;
+         end case;
    end case;
 
    package Compiler is


### PR DESCRIPTION
Library_Options shouldn't be set in the static case:
https://github.com/AdaCore/gprbuild/issues/27#issuecomment-298444608